### PR TITLE
adding timeout functionality

### DIFF
--- a/lib/Statistics/R.pm
+++ b/lib/Statistics/R.pm
@@ -506,15 +506,17 @@ sub run {
 			  $bridge->pump;
 		  }
 	  };
-
+	  
 	  # catch possible timeout
 	  if ( $@ ) {
-		  print "Timeout of " . $self->timeout . "s for R command '$cmd' exceeded. Terminating current bridge \n";
-		  print "DBG: $@ " if DEBUG;
-		  $self->_bridge->kill_kill;			  
-		  next CMD;
+		  if ( $@ =~ /timeout/ ) {
+			  print "Timeout of " . $self->timeout . "s for R command '$cmd' exceeded. Terminating current bridge\n";
+			  print "DBG: $@ \n" if DEBUG;
+			  $self->_bridge->kill_kill;			  
+			  next CMD;
+		  }
+		  die $@;
 	  }	  
-
       # Parse output, detect errors
       my $out = $self->_stdout;
       $out =~ s/${\(EOS_RE)}//;

--- a/t/09-timeout.t
+++ b/t/09-timeout.t
@@ -9,23 +9,20 @@ my ($R, $expected);
 
 ok $R = Statistics::R->new();
 
-ok $R->timeout(1);
+ok $R->timeout(0.1);
 
-# lengthy command timing out
+# command timing out
 $expected = '';
-is $R->run(q`mean(rt(100000000, df = 4))`), $expected;
+is $R->run(q`Sys.sleep(0.2)`), $expected;
 
-# quicker calculation not timing out
-$expected = '';
-ok ! $R->run(q`mean(rt(100, df = 4))`) eq '';
+# quick calculation not timing out, expecting result
+isnt $R->run(q`1+1`), $expected;
 
 # give timeout in constructor
-ok $R = Statistics::R->new( timeout => 1, shared => 1 );
-
-$expected = '';
-is $R->run(q`mean(rt(100000000, df = 4))`), $expected;
+ok $R = Statistics::R->new( timeout => 0.1, shared => 1 );
+is $R->run(q`Sys.sleep(0.2)`), $expected;
 
 # still times out with newly built bridge
-is $R->run(q`mean(rt(100000000, df = 4))`), $expected;
+is $R->run(q`Sys.sleep(0.2)`), $expected;
 
 done_testing;

--- a/t/09-timeout.t
+++ b/t/09-timeout.t
@@ -11,18 +11,18 @@ ok $R = Statistics::R->new();
 
 ok $R->timeout(0.1);
 
+my $func = 'function(){ Sys.sleep(2); return (1) }';
+$R->run(qq`func <- $func` );
+
 # command timing out
 $expected = '';
-is $R->run(q`Sys.sleep(0.2)`), $expected;
+is $R->run(q`func()`), $expected;
 
 # quick calculation not timing out, expecting result
 isnt $R->run(q`1+1`), $expected;
 
 # give timeout in constructor
 ok $R = Statistics::R->new( timeout => 0.1, shared => 1 );
-is $R->run(q`Sys.sleep(0.2)`), $expected;
-
-# still times out with newly built bridge
-is $R->run(q`Sys.sleep(0.2)`), $expected;
+$R->run(qq`func <- $func` );
 
 done_testing;

--- a/t/09-timeout.t
+++ b/t/09-timeout.t
@@ -1,0 +1,31 @@
+#! perl
+
+use strict;
+use warnings;
+use Test::More;
+use Statistics::R;
+
+my ($R, $expected);
+
+ok $R = Statistics::R->new();
+
+ok $R->timeout(1);
+
+# lengthy command timing out
+$expected = '';
+is $R->run(q`mean(rt(100000000, df = 4))`), $expected;
+
+# quicker calculation not timing out
+$expected = '';
+ok ! $R->run(q`mean(rt(100, df = 4))`) eq '';
+
+# give timeout in constructor
+ok $R = Statistics::R->new( timeout => 1, shared => 1 );
+
+$expected = '';
+is $R->run(q`mean(rt(100000000, df = 4))`), $expected;
+
+# still times out with newly built bridge
+is $R->run(q`mean(rt(100000000, df = 4))`), $expected;
+
+done_testing;


### PR DESCRIPTION
I made an attempt to implement timeouts using the functionality in `IPC::Run`. Timeouts (in seconds) can now be set as follows:

    my $R = Statistics::R->new;
    $R->timeout(10)

or, directly in the constructor: `my $R = Statistics::R->new(timeout=>10)`.
If a timeout for an R command is reached, an message is printed and the current bridge is terminated. If multiple commands are passed to `run` and e.g. the first one times out, the other ones are still executed (which might however give an error in running the R command if it depends on a variable created in the command that was timed out ).

This addresses issue #7.