### PR TITLE
Add error for "too many arguments to set"

### DIFF
--- a/lib/Statistics/R.pm
+++ b/lib/Statistics/R.pm
@@ -594,6 +594,7 @@ sub result {
 sub set {
    # Assign a variable or array of variables in R. Use undef if you want to
    # assign NULL to an R variable
+   die "Error: too many arguments to set" if @_>3;
    my ($self, $varname, $arr) = @_;
     
    # Start R now if it is not already running

--- a/t/06-get-set.t
+++ b/t/06-get-set.t
@@ -118,6 +118,12 @@ is ref($output), '';
 is $output, q{He said: "Let's go \\\\\\\\\\\\\"home\\\\\\\\\\\\\" now!\n"};
 
 
+is eval {
+    $R->set('x', 'foo', 'bar')
+}, undef;
+like $@, qr/\btoo many arguments to set\b/i;
+
+
 ok $R->stop();
 
 done_testing;


### PR DESCRIPTION
In case someone accidentally passes an array or list instead of an arrayref, like in this case: <https://www.perlmonks.org/?node_id=1230256>