### PR TITLE
Allow prove to run without '.' in @INC

### DIFF
--- a/t/08-errors.t
+++ b/t/08-errors.t
@@ -37,8 +37,10 @@ SKIP: {
 
    is $R->run(q`a <- 1;`), '';
 
-   use_ok 't::FlawedStatisticsR';
-   ok $R = t::FlawedStatisticsR->new();
+   use FindBin;
+   use lib $FindBin::Bin;
+   use_ok 'FlawedStatisticsR';
+   ok $R = FlawedStatisticsR->new();
    eval {
       $R->run( qq`print("Hello");\ncolors<-c("red")` );
    };

--- a/t/FlawedStatisticsR.pm
+++ b/t/FlawedStatisticsR.pm
@@ -1,4 +1,4 @@
-package t::FlawedStatisticsR;
+package FlawedStatisticsR;
 
 use Statistics::R;
 use base qw(Statistics::R);


### PR DESCRIPTION
When trying to run a `prove -l`, I was getting `Error:  Can't locate t/FlawedStatisticsR.pm in @INC (you may need to install the t::FlawedStatisticsR module)`, probably because `.` was removed from `@INC`. This patch should fix that.